### PR TITLE
Fix typeof array condition

### DIFF
--- a/src/rails.js
+++ b/src/rails.js
@@ -187,16 +187,16 @@
 
         function buildParamsInputs(key, value) {
           switch (typeof value) {
-            case 'array':
-              var result = [];
-              for (var i = 0, l = value.length; i < l; i++) {
-                result.push( buildParamsInputs(key === null ? i : key + '[' + i + ']', value[i]) );
-              }
-              return result.join('');
             case 'object':
               var result = [];
-              for (var i in value) {
-                result.push( buildParamsInputs(key === null ? i : key + '[' + i + ']', value[i]) );
+              if ($.isArray(value)) {
+                for (var i = 0, l = value.length; i < l; i++) {
+                  result.push( buildParamsInputs(key === null ? i : key + '[]', value[i]) );
+                }
+              } else {
+                for (var i in value) {
+                  result.push( buildParamsInputs(key === null ? i : key + '[' + i + ']', value[i]) );
+                }
               }
               return result.join('');
             default:


### PR DESCRIPTION
I see rails/jquery-ujs PR #395, but it don't work normally by array params.

``` html
<a href="xxx" data-method="post" data-params="{key:['val1','val2']}">xxx</a>
```

I expect the following movement rails controller params.

``` ruby
{ "key" => ["val1", "val2"] }
```

However, I really work as follows.

``` ruby
{ "key" => { "0" => "val1", "1" => "val2" } }
```

Is this movement not a problem? Javascript typeof don't match 'array', should I use 'jQuery.isArray'
